### PR TITLE
Support netstandard 1.4

### DIFF
--- a/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
+++ b/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Piwik.Tracker\AttributionInfo.cs" Link="AttributionInfo.cs" />
+    <Compile Include="..\Piwik.Tracker\BrowserPlugins.cs" Link="BrowserPlugins.cs" />
+    <Compile Include="..\Piwik.Tracker\CryptoExtensions.cs" Link="CryptoExtensions.cs" />
+    <Compile Include="..\Piwik.Tracker\CustomVar.cs" Link="CustomVar.cs" />
+    <Compile Include="..\Piwik.Tracker\Enums.cs" Link="Enums.cs" />
+    <Compile Include="..\Piwik.Tracker\HttpContextExtensions.cs" Link="HttpContextExtensions.cs" />
+    <Compile Include="..\Piwik.Tracker\PiwikTracker.cs" Link="PiwikTracker.cs" />
+    <Compile Include="..\Piwik.Tracker\SerializerExtensions.cs" Link="SerializerExtensions.cs" />
+    <Compile Include="..\Piwik.Tracker\TrackingResponse.cs" Link="TrackingResponse.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
+++ b/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
@@ -8,6 +8,7 @@
     <Compile Include="..\Piwik.Tracker\AttributionInfo.cs" Link="AttributionInfo.cs" />
     <Compile Include="..\Piwik.Tracker\BrowserPlugins.cs" Link="BrowserPlugins.cs" />
     <Compile Include="..\Piwik.Tracker\CookiesExtensions.cs" Link="CookiesExtensions.cs" />
+    <Compile Include="..\Piwik.Tracker\DateTimeUtils.cs" Link="DateTimeUtils.cs" />
     <Compile Include="..\Piwik.Tracker\CryptoExtensions.cs" Link="CryptoExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\CustomVar.cs" Link="CustomVar.cs" />
     <Compile Include="..\Piwik.Tracker\Enums.cs" Link="Enums.cs" />

--- a/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
+++ b/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
@@ -7,13 +7,16 @@
   <ItemGroup>
     <Compile Include="..\Piwik.Tracker\AttributionInfo.cs" Link="AttributionInfo.cs" />
     <Compile Include="..\Piwik.Tracker\BrowserPlugins.cs" Link="BrowserPlugins.cs" />
+    <Compile Include="..\Piwik.Tracker\CookiesExtensions.cs" Link="CookiesExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\CryptoExtensions.cs" Link="CryptoExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\CustomVar.cs" Link="CustomVar.cs" />
     <Compile Include="..\Piwik.Tracker\Enums.cs" Link="Enums.cs" />
     <Compile Include="..\Piwik.Tracker\HttpContextExtensions.cs" Link="HttpContextExtensions.cs" />
+    <Compile Include="..\Piwik.Tracker\HttpRequestExtensions.cs" Link="HttpRequestExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\PiwikTracker.cs" Link="PiwikTracker.cs" />
     <Compile Include="..\Piwik.Tracker\SerializerExtensions.cs" Link="SerializerExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\TrackingResponse.cs" Link="TrackingResponse.cs" />
+    <Compile Include="..\Piwik.Tracker\WebExtensions.cs" Link="WebExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
+++ b/Piwik.Tracker.NetStandard1.4/Piwik.Tracker.NetStandard1.4.csproj
@@ -12,7 +12,6 @@
     <Compile Include="..\Piwik.Tracker\CryptoExtensions.cs" Link="CryptoExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\CustomVar.cs" Link="CustomVar.cs" />
     <Compile Include="..\Piwik.Tracker\Enums.cs" Link="Enums.cs" />
-    <Compile Include="..\Piwik.Tracker\HttpContextExtensions.cs" Link="HttpContextExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\HttpRequestExtensions.cs" Link="HttpRequestExtensions.cs" />
     <Compile Include="..\Piwik.Tracker\PiwikTracker.cs" Link="PiwikTracker.cs" />
     <Compile Include="..\Piwik.Tracker\SerializerExtensions.cs" Link="SerializerExtensions.cs" />

--- a/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
+++ b/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="PiwikTrackerTests.cs" />
     <Compile Include="PiwikTrackerWithMockedServerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializerExtensionsTests.cs" />
     <Compile Include="UnitTestExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Piwik.Tracker.Tests/SerializerExtensionsTests.cs
+++ b/Piwik.Tracker.Tests/SerializerExtensionsTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace Piwik.Tracker.Tests
+{
+    [TestFixture]
+    internal class SerializerExtensionsTests
+    {
+        private static readonly string[] ArrayToSerialize = { "314", "ilughl", "üöä", "" };
+        private static readonly string SerializedArray = "[\"314\",\"ilughl\",\"üöä\",\"\"]";
+        private static readonly TestClass ClassToSerialize = new TestClass();
+        private const string SerializedClass = "{\"StringProperty\":\"dshsdhfg34656(/%/$\\u0026/%§üÄÖ..-;\",\"IntProperty\":34534,\"DoubleProperty\":-0.54235234,\"Childreen\":[{\"IntProperty\":34534},{\"IntProperty\":34534},{\"IntProperty\":34534}]}";
+
+        [Test]
+        public void Serialize_Test()
+        {
+            //Act
+            var actualSerialized = ClassToSerialize.Serialize();
+            //Assert
+            Assert.That(actualSerialized, Is.EqualTo(SerializedClass));
+
+            //Act
+            actualSerialized = ArrayToSerialize.Serialize();
+            //Assert
+            Assert.That(actualSerialized, Is.EqualTo(SerializedArray));
+        }
+
+        [Test]
+        public void Deserialize_Test()
+        {
+            //Act
+            var actualDeserialized = SerializedClass.Deserialize<TestClass>();
+            //Assert
+            Assert.That(actualDeserialized.StringProperty, Is.EqualTo(ClassToSerialize.StringProperty));
+            Assert.That(actualDeserialized.IntProperty, Is.EqualTo(ClassToSerialize.IntProperty));
+            Assert.That(actualDeserialized.DoubleProperty, Is.EqualTo(ClassToSerialize.DoubleProperty));
+            Assert.That(actualDeserialized.Childreen.Select(c => c.IntProperty), Is.EqualTo(ClassToSerialize.Childreen.Select(c => c.IntProperty)));
+
+            //Act
+            var actualDeserializedArray = SerializedArray.Deserialize<string[]>();
+            //Assert
+            Assert.That(string.Join(",", actualDeserializedArray), Is.EqualTo(string.Join(",", ArrayToSerialize)));
+        }
+
+        private class TestClass
+        {
+            public string StringProperty { get; set; } = "dshsdhfg34656(/%/$&/%§üÄÖ..-;";
+            public int IntProperty { get; set; } = 34534;
+            public double DoubleProperty { get; set; } = -0.54235234;
+
+            public TestClassChild[] Childreen { get; set; } =
+            {
+                new TestClassChild(),
+                new TestClassChild(),
+                new TestClassChild(),
+            };
+        }
+
+        private class TestClassChild
+        {
+            public int IntProperty { get; set; } = 34534;
+        }
+    }
+}

--- a/Piwik.Tracker.sln
+++ b/Piwik.Tracker.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piwik.Tracker", "Piwik.Tracker\Piwik.Tracker.csproj", "{C3BB0E94-F45C-4691-81FF-061FC20E3209}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piwik.Tracker.Web.Samples", "Piwik.Tracker.Web.Samples\Piwik.Tracker.Web.Samples.csproj", "{3D74EB7C-F2A4-49E4-8B2C-8247322F7DE0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piwik.Tracker.Tests", "Piwik.Tracker.Tests\Piwik.Tracker.Tests.csproj", "{A6F87572-AB3D-477E-A97E-300DFED8CB5C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piwik.Tracker.NetStandard1.4", "Piwik.Tracker.NetStandard1.4\Piwik.Tracker.NetStandard1.4.csproj", "{A17AF492-7F5D-4BBF-985B-EFB492285C01}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +52,14 @@ Global
 		{A6F87572-AB3D-477E-A97E-300DFED8CB5C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A6F87572-AB3D-477E-A97E-300DFED8CB5C}.Release|x86.ActiveCfg = Release|Any CPU
 		{A6F87572-AB3D-477E-A97E-300DFED8CB5C}.Release|x86.Build.0 = Release|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Debug|x86.Build.0 = Debug|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Release|x86.ActiveCfg = Release|Any CPU
+		{A17AF492-7F5D-4BBF-985B-EFB492285C01}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Piwik.Tracker/CookiesExtensions.cs
+++ b/Piwik.Tracker/CookiesExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+#if NETSTANDARD1_4
+using Microsoft.AspNetCore.Http;
+#else
+using System.Web;
+#endif
+
+namespace Piwik.Tracker 
+{
+    internal static class CookiesExtensions 
+    {
+#if NETSTANDARD1_4
+        public static void Add(this IResponseCookies cookies, string cookieName, string cookieValue,
+                DateTime expirationUtc, string domain, string path) 
+        {
+            cookies.Append(cookieName, cookieValue, new CookieOptions() { Expires = expirationUtc, Domain = domain, Path = path });
+        }
+#else
+        public static void Add(this HttpCookieCollection cookies, string cookieName, string cookieValue,
+                DateTime expirationUtc, string domain, string path) 
+        {
+            cookies.Add(new HttpCookie(cookieName, cookieValue) { Expires = expirationUtc, Domain = domain, Path = path });
+        }
+#endif
+    }
+}

--- a/Piwik.Tracker/CryptoExtensions.cs
+++ b/Piwik.Tracker/CryptoExtensions.cs
@@ -31,7 +31,7 @@ namespace Piwik.Tracker
             {
                 throw new ArgumentNullException(nameof(valueToEncrypt));
             }
-            using (var provider = new SHA1CryptoServiceProvider())
+            using (var provider = SHA1.Create())
             {
                 var encodedBytes = provider.ComputeHash(valueToEncrypt);
                 var sb = new StringBuilder();

--- a/Piwik.Tracker/HttpContextExtensions.cs
+++ b/Piwik.Tracker/HttpContextExtensions.cs
@@ -1,6 +1,0 @@
-﻿namespace Piwik.Tracker
-{
-    internal static class HttpContextExtensions
-    {
-    }
-}

--- a/Piwik.Tracker/HttpContextExtensions.cs
+++ b/Piwik.Tracker/HttpContextExtensions.cs
@@ -1,0 +1,6 @@
+﻿namespace Piwik.Tracker
+{
+    internal static class HttpContextExtensions
+    {
+    }
+}

--- a/Piwik.Tracker/HttpRequestExtensions.cs
+++ b/Piwik.Tracker/HttpRequestExtensions.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Text;
+#if NETSTANDARD1_4
+using Microsoft.AspNetCore.Http;
+#else
+using System.Web;
+#endif
+
+namespace Piwik.Tracker 
+{
+    internal static class HttpRequestExtensions
+    {
+        public static Uri GetUrl(this HttpRequest request)
+        {
+#if NETSTANDARD1_4
+            if (request == null)
+                throw new ArgumentNullException("request");
+            if (string.IsNullOrWhiteSpace(request.Scheme))
+                throw new ArgumentException("HttpRequest Scheme not specified");
+            if (!request.Host.HasValue)
+                throw new ArgumentException("HttpRequest Host not specified");
+            var sb = new StringBuilder();
+            sb.Append(request.Scheme).Append("://").Append(request.Host);
+            if (request.Path.HasValue)
+                sb.Append(request.Path.Value);
+            if (request.QueryString.HasValue)
+                sb.Append(request.QueryString.ToString());
+            return new Uri(sb.ToString());
+#else
+            return request.Url;
+#endif
+        }
+
+#if NETSTANDARD1_4
+        public static Uri GetUrlReferrer(this HttpRequest request)
+        {
+            var s = request.Headers["Referer"].ToString();
+            if (string.IsNullOrEmpty(s)) {
+                return null;
+            }
+            try {
+                return s.IndexOf("://", StringComparison.Ordinal) < 0 ? new Uri(request.GetUrl(), s) : new Uri(s);
+            } catch {
+                return null;
+            }
+        }
+#else
+        public static Uri GetUrlReferrer(this HttpRequest request) 
+        {
+            return request.UrlReferrer;
+        }
+#endif
+
+
+#if NETSTANDARD1_4
+        public static string GetUserAgent(this HttpRequest request) 
+        {
+            return request?.Headers["User-Agent"].ToString();
+        }
+#else
+        public static string GetUserAgent(this HttpRequest request) 
+        {
+            return request?.UserAgent;
+        }
+#endif
+
+#if NETSTANDARD1_4
+        public static string GetFirstUserLanguage(this HttpRequest request) 
+        {
+            return request?.Headers["Accept-Language"].FirstOrDefault();
+        }
+#else
+        public static string GetFirstUserLanguage(this HttpRequest request) 
+        {
+            return request?.UserLanguages?.FirstOrDefault();
+        }
+#endif
+
+#if NETSTANDARD1_4
+        public static string GetUserHostAddress(this HttpRequest request) 
+        {
+            return request.HttpContext.Connection.RemoteIpAddress.ToString();
+        }
+#else
+        public static string GetUserHostAddress(this HttpRequest request) 
+        {
+            return request?.UserHostAddress;
+        }
+#endif
+    }
+}

--- a/Piwik.Tracker/Piwik.Tracker.csproj
+++ b/Piwik.Tracker/Piwik.Tracker.csproj
@@ -46,15 +46,18 @@
   <ItemGroup>
     <Compile Include="AttributionInfo.cs" />
     <Compile Include="BrowserPlugins.cs" />
+    <Compile Include="CookiesExtensions.cs" />
     <Compile Include="DateTimeUtils.cs" />
     <Compile Include="CryptoExtensions.cs" />
     <Compile Include="CustomVar.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="HttpContextExtensions.cs" />
+    <Compile Include="HttpRequestExtensions.cs" />
     <Compile Include="PiwikTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializerExtensions.cs" />
     <Compile Include="TrackingResponse.cs" />
+    <Compile Include="WebExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Piwik.Tracker/Piwik.Tracker.csproj
+++ b/Piwik.Tracker/Piwik.Tracker.csproj
@@ -50,6 +50,7 @@
     <Compile Include="CryptoExtensions.cs" />
     <Compile Include="CustomVar.cs" />
     <Compile Include="Enums.cs" />
+    <Compile Include="HttpContextExtensions.cs" />
     <Compile Include="PiwikTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializerExtensions.cs" />

--- a/Piwik.Tracker/Piwik.Tracker.csproj
+++ b/Piwik.Tracker/Piwik.Tracker.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -52,6 +52,7 @@
     <Compile Include="Enums.cs" />
     <Compile Include="PiwikTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializerExtensions.cs" />
     <Compile Include="TrackingResponse.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Piwik.Tracker/Piwik.Tracker.csproj
+++ b/Piwik.Tracker/Piwik.Tracker.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -51,7 +51,6 @@
     <Compile Include="CryptoExtensions.cs" />
     <Compile Include="CustomVar.cs" />
     <Compile Include="Enums.cs" />
-    <Compile Include="HttpContextExtensions.cs" />
     <Compile Include="HttpRequestExtensions.cs" />
     <Compile Include="PiwikTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -1477,7 +1477,7 @@ namespace Piwik.Tracker
 
             if (!string.IsNullOrEmpty(data)) 
             {
-                rm.Content = new StringContent(data, Encoding.UTF8, "application/json");
+                rm.Content = new StringContent(data, System.Text.Encoding.UTF8, "application/json");
             }
 
             using (var result = HttpClient.SendAsync(rm).Result) 
@@ -1766,7 +1766,7 @@ namespace Piwik.Tracker
             if (_httpContext != null)
             {
                 var cookieExpire = _currentTs + cookieTtl;
-                _httpContext.Response.Cookies.Add(new HttpCookie(GetCookieName(cookieName), cookieValue) { Expires = DateTimeUtils.UnixEpoch.AddSeconds(cookieExpire), Path = _configCookiePath, Domain = _configCookieDomain });
+                _httpContext.Response.Cookies.Add(GetCookieName(cookieName), cookieValue, DateTimeUtils.UnixEpoch.AddSeconds(cookieExpire), _configCookieDomain, _configCookiePath);
             }
         }
 

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -736,7 +736,7 @@ namespace Piwik.Tracker
                 data["token_auth"] = _tokenAuth;
             }
 
-            var postData = new JavaScriptSerializer().Serialize(data);
+            var postData = data.Serialize();
             var response = SendRequest(PiwikBaseUrl, "POST", postData, true);
 
             _storedTrackingActions = new List<string>();
@@ -801,7 +801,7 @@ namespace Piwik.Tracker
             var serializedCategories = "";
             if (categories != null)
             {
-                serializedCategories = new JavaScriptSerializer().Serialize(categories);
+                serializedCategories = categories.Serialize();
             }
             SetCustomVariable(CvarIndexEcommerceItemCategory, "_pkc", serializedCategories, Scopes.Page);
 
@@ -903,7 +903,7 @@ namespace Piwik.Tracker
 
             if (_ecommerceItems.Count > 0)
             {
-                url += "&ec_items=" + UrlEncode(new JavaScriptSerializer().Serialize(_ecommerceItems.Values));
+                url += "&ec_items=" + UrlEncode(_ecommerceItems.Values.Serialize());
             }
 
             _ecommerceItems = new Dictionary<string, object[]>();
@@ -1300,7 +1300,7 @@ namespace Piwik.Tracker
                 return null;
             }
 
-            var cookieDecoded = new JavaScriptSerializer().Deserialize<string[]>(HttpUtility.UrlDecode(refCookie.Value ?? string.Empty));
+            var cookieDecoded = HttpUtility.UrlDecode(refCookie.Value ?? string.Empty).Deserialize<string[]>();
 
             if (cookieDecoded == null)
             {
@@ -1523,9 +1523,9 @@ namespace Piwik.Tracker
                     (!_ecommerceLastOrderTimestamp.Equals(DateTimeOffset.MinValue) ? "&_ects=" + DateTimeUtils.ConvertToUnixTime(_ecommerceLastOrderTimestamp) : "") +
 
                     // Various important attributes
-                    (_visitorCustomVar.Any() ? "&_cvar=" + UrlEncode(new JavaScriptSerializer().Serialize(_visitorCustomVar)) : "") +
-                    (_pageCustomVar.Any() ? "&cvar=" + UrlEncode(new JavaScriptSerializer().Serialize(_pageCustomVar)) : "") +
-                    (_eventCustomVar.Any() ? "&e_cvar=" + UrlEncode(new JavaScriptSerializer().Serialize(_eventCustomVar)) : "") +
+                    (_visitorCustomVar.Any() ? "&_cvar=" + UrlEncode(_visitorCustomVar.Serialize()) : "") +
+                    (_pageCustomVar.Any() ? "&cvar=" + UrlEncode(_pageCustomVar.Serialize()) : "") +
+                    (_eventCustomVar.Any() ? "&e_cvar=" + UrlEncode(_eventCustomVar.Serialize()) : "") +
                     (_generationTime != null ? "&gt_ms=" + _generationTime : "") +
                     (!string.IsNullOrEmpty(_forcedVisitorId) ? "&cid=" + _forcedVisitorId : "&_id=" + GetVisitorId()) +
 
@@ -1674,7 +1674,7 @@ namespace Piwik.Tracker
             var attributionInfo = GetAttributionInfo();
             if (attributionInfo != null)
             {
-                SetCookie("ref", UrlEncode(new JavaScriptSerializer().Serialize(attributionInfo.ToArray())), ConfigReferralCookieTimeout);
+                SetCookie("ref", UrlEncode(attributionInfo.ToArray().Serialize()), ConfigReferralCookieTimeout);
             }
 
             // Set the 'ses' cookie
@@ -1686,7 +1686,7 @@ namespace Piwik.Tracker
             SetCookie("id", cookieValue, ConfigVisitorCookieTimeout);
 
             // Set the 'cvar' cookie
-            SetCookie("cvar", UrlEncode(new JavaScriptSerializer().Serialize(_visitorCustomVar)), ConfigSessionCookieTimeout);
+            SetCookie("cvar", UrlEncode(_visitorCustomVar.Serialize()), ConfigSessionCookieTimeout);
         }
 
         /// <summary>
@@ -1716,7 +1716,7 @@ namespace Piwik.Tracker
             {
                 return new Dictionary<string, string[]>();
             }
-            return new JavaScriptSerializer().Deserialize<Dictionary<string, string[]>>(HttpUtility.UrlDecode(cookie.Value ?? string.Empty));
+            return HttpUtility.UrlDecode(cookie.Value ?? string.Empty).Deserialize<Dictionary<string, string[]>>();
         }
 
         private string FormatDateValue(DateTimeOffset date)

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -17,8 +17,18 @@ namespace Piwik.Tracker
     using System.Linq;
     using System.Net;
     using System.Globalization;
-    using System.Web;
     using System.Text.RegularExpressions;
+
+#if NETSTANDARD1_4
+
+    // HttpContext.Current has been removed from .Net.Core: Everywhere the HTTP context is needed, declare an IHttpContextAccessor dependency and use it to fetch the context.
+    using Microsoft.AspNetCore.Http;
+
+#else
+
+    using System.Web;
+
+#endif
 
     /// <summary>
     /// PiwikTracker implements the Piwik Tracking Web API.

--- a/Piwik.Tracker/SerializerExtensions.cs
+++ b/Piwik.Tracker/SerializerExtensions.cs
@@ -1,0 +1,32 @@
+﻿#if NETSTANDARD1_4
+//  .Net.Core dropped the JavaScriptSerializer in favor of the widely used Newtonsoft.Json package.
+    using Newtonsoft.Json;
+#else
+
+using System.Web.Script.Serialization;
+
+#endif
+
+namespace Piwik.Tracker
+{
+    internal static class SerializerExtensions
+    {
+        public static TReturn Deserialize<TReturn>(this string value)
+        {
+#if NETSTANDARD1_4
+            return JsonConvert.DeserializeObject<TReturn>(value);
+#else
+            return new JavaScriptSerializer().Deserialize<TReturn>(value);
+#endif
+        }
+
+        public static string Serialize(this object value)
+        {
+#if NETSTANDARD1_4
+            return JsonConvert.SerializeObject(value);
+#else
+            return new JavaScriptSerializer().Serialize(value);
+#endif
+        }
+    }
+}

--- a/Piwik.Tracker/WebExtensions.cs
+++ b/Piwik.Tracker/WebExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace Piwik.Tracker
+{
+    internal static class WebExtensions
+    {
+        public static string UrlDecode(this string value)
+        {
+#if NETSTANDARD1_4
+            return System.Net.WebUtility.UrlDecode(value);
+#else
+            return System.Web.HttpUtility.UrlDecode(value);
+#endif
+        }
+
+        public static string UrlEncode(this string value)
+        {
+#if NETSTANDARD1_4
+            return System.Net.WebUtility.UrlEncode(value);
+#else
+            return System.Web.HttpUtility.UrlEncode(value);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
I've extended some work initially done by @ptr1120 to support .NET standard.

Most changes are unobtrusive, however there is a change externally visible to the API:

Under .NET standard, the Proxy and RequestTimeout settings are static.  This is to facilitate the recommended singleton usage of HttpClient (the HttpWebRequest replacement).