### PR TITLE
Fix DoTrackAction with ActionType.Download is not tracked as a download

### DIFF
--- a/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
+++ b/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
@@ -10,7 +10,7 @@ namespace Piwik.Tracker.Samples
     internal class PiwikTrackerSamples
     {
         private const string UA = "Firefox";
-        private static readonly string PiwikBaseUrl = "http://10.10.158.189:9090";
+        private static readonly string PiwikBaseUrl = "http://piwik.local";
         private static readonly int SiteId = 1;
 
         private static void Main(string[] args)
@@ -54,7 +54,6 @@ namespace Piwik.Tracker.Samples
             // ** Event Tracking **
             //            TrackSongPlayback();
 
-            TrackDownload();
             Console.ReadKey(true);
         }
 
@@ -138,11 +137,9 @@ namespace Piwik.Tracker.Samples
 
             piwikTracker.SetTokenAuth("XYZ");
 
-            var browserPluginsToSet = new BrowserPlugins
-            {
-                Silverlight = true,
-                Flash = true
-            };
+            var browserPluginsToSet = new BrowserPlugins();
+            browserPluginsToSet.Silverlight = true;
+            browserPluginsToSet.Flash = true;
             piwikTracker.SetPlugins(browserPluginsToSet);
             piwikTracker.SetBrowserHasCookies(true);
 
@@ -182,7 +179,7 @@ namespace Piwik.Tracker.Samples
         /// </summary>
         static private void RecordSimplePageViewWithGenerationTime()
         {
-            PiwikTracker piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
+            var piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
             piwikTracker.SetUserAgent(UA);
 
             piwikTracker.SetGenerationTime(10000);
@@ -234,7 +231,7 @@ namespace Piwik.Tracker.Samples
         {
             var piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
             piwikTracker.SetUserAgent(UA);
-            var url = "http://10.10.158.246/piwik.org/path/again/latest.zip";
+            var url = "http://piwik.org/path/again/latest.zip";
             piwikTracker.SetUrl(url);
             var response = piwikTracker.DoTrackAction(url, ActionType.Download);
 

--- a/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
+++ b/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
@@ -10,7 +10,7 @@ namespace Piwik.Tracker.Samples
     internal class PiwikTrackerSamples
     {
         private const string UA = "Firefox";
-        private static readonly string PiwikBaseUrl = "http://piwik.local";
+        private static readonly string PiwikBaseUrl = "http://10.10.158.189:9090";
         private static readonly int SiteId = 1;
 
         private static void Main(string[] args)
@@ -54,6 +54,7 @@ namespace Piwik.Tracker.Samples
             // ** Event Tracking **
             //            TrackSongPlayback();
 
+            TrackDownload();
             Console.ReadKey(true);
         }
 
@@ -129,7 +130,7 @@ namespace Piwik.Tracker.Samples
             piwikTracker.SetResolution(1600, 1400);
 
             piwikTracker.SetIp("192.168.52.64");
-            piwikTracker.SetVisitorId("33c31B01394bdc65");
+            piwikTracker.SetUserId("33c31B01394bdc65");
 
             piwikTracker.SetForceVisitDateTime(new DateTime(2011, 10, 23, 10, 20, 50, DateTimeKind.Utc));
 
@@ -137,9 +138,11 @@ namespace Piwik.Tracker.Samples
 
             piwikTracker.SetTokenAuth("XYZ");
 
-            var browserPluginsToSet = new BrowserPlugins();
-            browserPluginsToSet.Silverlight = true;
-            browserPluginsToSet.Flash = true;
+            var browserPluginsToSet = new BrowserPlugins
+            {
+                Silverlight = true,
+                Flash = true
+            };
             piwikTracker.SetPlugins(browserPluginsToSet);
             piwikTracker.SetBrowserHasCookies(true);
 
@@ -179,7 +182,7 @@ namespace Piwik.Tracker.Samples
         /// </summary>
         static private void RecordSimplePageViewWithGenerationTime()
         {
-            var piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
+            PiwikTracker piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
             piwikTracker.SetUserAgent(UA);
 
             piwikTracker.SetGenerationTime(10000);
@@ -231,8 +234,9 @@ namespace Piwik.Tracker.Samples
         {
             var piwikTracker = new PiwikTracker(SiteId, PiwikBaseUrl);
             piwikTracker.SetUserAgent(UA);
-
-            var response = piwikTracker.DoTrackAction("http://piwik.org/path/again/latest.zip", ActionType.Download);
+            var url = "http://10.10.158.246/piwik.org/path/again/latest.zip";
+            piwikTracker.SetUrl(url);
+            var response = piwikTracker.DoTrackAction(url, ActionType.Download);
 
             DisplayDebugInfo(response);
         }

--- a/Piwik.Tracker.Web.Samples/Piwik.Tracker.Web.Samples.csproj.user
+++ b/Piwik.Tracker.Web.Samples/Piwik.Tracker.Web.Samples.csproj.user
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+  </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -1099,7 +1099,7 @@ namespace Piwik.Tracker
         public string GetUrlTrackAction(string actionUrl, ActionType actionType)
         {
             var url = GetRequest(IdSite);
-            url += "&" + actionType + "=" + UrlEncode(actionUrl);
+            url += "&" + actionType.ToString().ToLower() + "=" + UrlEncode(actionUrl);
             return url;
         }
 
@@ -1420,7 +1420,7 @@ namespace Piwik.Tracker
             _configCookiesDisabled = true;
         }
 
-        private TrackingResponse SendRequest(string url, string method = "GET", string data = null, bool force = false)
+        public TrackingResponse SendRequest(string url, string method = "GET", string data = null, bool force = false)
         {
             // if doing a bulk request, store the url
             if (_doBulkRequests && !force)


### PR DESCRIPTION
Fix for issue #68 
Issue:
When posting a download action with query parameter Downalod (capital D), it is tracked as a page view instead of download action.

More Details:
https://github.com/matomo-org/matomo/issues/14396
https://github.com/matomo-org/matomo/issues/10534

Notes:
(1) Changes in PiwikTrackerSamples are:
- Change TrackDownload to set the url too, which is recommended by Matomo documentation.

(2) Changes in PiwikTracker are:
- fix GetUrlTrackAction to set the actionType with lower case 
- change SendRequest, so in case of similar bugs or matomo added a new url parameters and it are not added yet to the .net client, users can get the url (i.e. using GetUrlTrackAction) and use SendRequest to post it to Matomo. 
